### PR TITLE
Do not fall back to author-associated role for blog posts (fixes #18)

### DIFF
--- a/ietf/blog/templates/blog/blog_page.html
+++ b/ietf/blog/templates/blog/blog_page.html
@@ -33,8 +33,6 @@
                                         <li class="title">{{ a.author.name }}</li>
                                         {% if a.role %}
                                             <li>{{ a.role.name }}</li>
-                                        {% else %}
-                                            <li>{{ a.author.role }}</li>
                                         {% endif %}
                                     </ul>
                                 {% endfor %}
@@ -131,8 +129,6 @@
                         <li class="title">{{ a.author.name }}</li>
                         {% if a.role %}
                             <li>{{ a.role.name }}</li>
-                        {% else %}
-                            <li>{{ a.author.role.name }}</li>
                         {% endif %}
                     </ul>
                 {% endfor %}
@@ -165,8 +161,6 @@
                                         <li class="title">{{ a.author.name }}</li>
                                         {% if a.role %}
                                             <li>{{ a.role.name }}</li>
-                                        {% else %}
-                                            <li>{{ a.author.role }}</li>
                                         {% endif %}
                                     </ul>
                                 {% endfor %}


### PR DESCRIPTION
As described in the discussion on #18, the blog post displays should only display a role for an author if it explicitly associated with them. The mechanism for that is a "role override." This pull request removes the template code that fell back to a role associated with the author when there was no role override.

The formatting issue (unwanted separator) is cleaned up by this as well. That was a side effect of a bug in the now-removed code that rendered an empty `<li></li>` in place of the role, triggering the CSS to display a separator between them.